### PR TITLE
Update verifying_scan_results.md

### DIFF
--- a/docs/verifying_scan_results.md
+++ b/docs/verifying_scan_results.md
@@ -43,6 +43,12 @@ Each of these image tags are available in both `-wolfi` and `-chainguard` flavor
 **Expected:**
 
 - CVE-2023-25139
+- CVE-2023-4911
+- CVE-2023-5156
+- CVE-2023-6246
+- CVE-2023-6779
+- CVE-2023-4527
+- CVE-2023-6780 
 
 **Why:** This image contains an **intentionally outdated** version of `glibc`, to see if scanners recognize that there's a vulnerability in this package that's fixed in a _later_ version of the package.
 
@@ -93,13 +99,24 @@ Each of these image tags are available in both `-wolfi` and `-chainguard` flavor
 
 **Expected:**
 
+- CVE-2022-4450
+- CVE-2023-0215
+- CVE-2023-0216
+- CVE-2023-0217
+- CVE-2023-0286
+- CVE-2023-0401
 - CVE-2023-0464
+- CVE-2023-5363
+- CVE-2022-4203
+- CVE-2022-4304
 - CVE-2023-0465
 - CVE-2023-1255
 - CVE-2023-2650
 - CVE-2023-2975
 - CVE-2023-3446
 - CVE-2023-3817
+- CVE-2023-5678
+- CVE-2024-0727
 
 **Why:** This image contains an **intentionally outdated** version of `libcrypto3`. `libcrypto3` is a subpackage of `openssl`, and the relevant secdb data is filed under `openssl`. This image tests that scanners understand how to relate subpackages to origin package data to find unfixed vulnerabilities.
 


### PR DESCRIPTION
Vulnerabilities have changed in two images since last edit.

Trivy output

ghcr.io/chainguard-images/scanner-test:unfixed-vulnerabilities-wolfi (wolfi 20230201)

Total: 7 (UNKNOWN: 0, LOW: 0, MEDIUM: 2, HIGH: 4, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ glibc   │ CVE-2023-25139 │ CRITICAL │ fixed  │ 2.36-r3           │ 2.37-r1       │ glibc: incorrect printf output for integers with thousands │
│         │                │          │        │                   │               │ separator and width field...                               │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-25139                 │
│         ├────────────────┼──────────┤        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-4911  │ HIGH     │        │                   │ 2.38-r5       │ glibc: buffer overflow in ld.so leading to privilege       │
│         │                │          │        │                   │               │ escalation                                                 │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-4911                  │
│         ├────────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-5156  │          │        │                   │ 2.38-r3       │ glibc: DoS due to memory leak in getaddrinfo.c             │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5156                  │
│         ├────────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-6246  │          │        │                   │ 2.38-r11      │ glibc: heap-based buffer overflow in __vsyslog_internal()  │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6246                  │
│         ├────────────────┤          │        │                   │               ├────────────────────────────────────────────────────────────┤
│         │ CVE-2023-6779  │          │        │                   │               │ glibc: off-by-one heap-based buffer overflow in            │
│         │                │          │        │                   │               │ __vsyslog_internal()                                       │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6779                  │
│         ├────────────────┼──────────┤        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-4527  │ MEDIUM   │        │                   │ 2.38-r2       │ glibc: Stack read overflow in getaddrinfo in no-aaaa mode  │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-4527                  │
│         ├────────────────┤          │        │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2023-6780  │          │        │                   │ 2.38-r11      │ glibc: integer overflow in __vsyslog_internal()            │
│         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6780                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

ghcr.io/chainguard-images/scanner-test:subpackage-unfixed-vulnerabilities-wolfi (wolfi 20230201)

Total: 18 (UNKNOWN: 0, LOW: 0, MEDIUM: 10, HIGH: 8, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2022-4450 │ HIGH     │ fixed  │ 3.0.8-r0          │ 3.1.0-r0      │ openssl: double free after calling PEM_read_bio_ex           │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4450                    │
│            ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0215 │          │        │                   │               │ openssl: use-after-free following BIO_new_NDEF               │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0215                    │
│            ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0216 │          │        │                   │               │ openssl: invalid pointer dereference in d2i_PKCS7 functions  │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0216                    │
│            ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0217 │          │        │                   │               │ openssl: NULL dereference validating DSA public key          │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0217                    │
│            ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0286 │          │        │                   │               │ openssl: X.400 address type confusion in X.509 GeneralName   │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0286                    │
│            ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0401 │          │        │                   │               │ openssl: NULL dereference during PKCS7 data verification     │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0401                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0464 │          │        │                   │ 3.1.0-r1      │ openssl: Denial of service by excessive resource usage in    │
│            │               │          │        │                   │               │ verifying X509 policy...                                     │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-5363 │          │        │                   │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing       │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363                    │
│            ├───────────────┼──────────┤        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4203 │ MEDIUM   │        │                   │ 3.1.0-r0      │ openssl: read buffer overflow in X.509 certificate           │
│            │               │          │        │                   │               │ verification                                                 │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4203                    │
│            ├───────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2022-4304 │          │        │                   │               │ openssl: timing attack in RSA Decryption implementation      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-4304                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0465 │          │        │                   │ 3.1.0-r2      │ openssl: Invalid certificate policies in leaf certificates   │
│            │               │          │        │                   │               │ are silently ignored                                         │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-1255 │          │        │                   │ 3.1.0-r5      │ openssl: Input buffer over-read in AES-XTS implementation on │
│            │               │          │        │                   │               │ 64 bit ARM                                                   │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-1255                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-2650 │          │        │                   │ 3.1.1-r0      │ openssl: Possible DoS translating ASN.1 object identifiers   │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-2975 │          │        │                   │ 3.1.1-r2      │ openssl: AES-SIV cipher implementation contains a bug that   │
│            │               │          │        │                   │               │ causes it to ignore...                                       │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3446 │          │        │                   │ 3.1.1-r3      │ openssl: Excessive time spent checking DH keys and           │
│            │               │          │        │                   │               │ parameters                                                   │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3817 │          │        │                   │ 3.1.1-r4      │ OpenSSL: Excessive time spent checking DH q parameter value  │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2023-5678 │          │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or        │
│            │               │          │        │                   │               │ checking excessively long X9.42...                           │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                    │
│            ├───────────────┤          │        │                   ├───────────────┼──────────────────────────────────────────────────────────────┤
│            │ CVE-2024-0727 │          │        │                   │ 3.2.1-r0      │ openssl: denial of service via null dereference              │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                    │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘