### PR TITLE
Improve scan result verification

### DIFF
--- a/data/answers.json
+++ b/data/answers.json
@@ -1,0 +1,67 @@
+{
+  "testCases": [
+    {
+      "testCaseName": "no-software",
+      "vulnerabilities": []
+    },
+    {
+      "testCaseName": "fixed-vulnerabilities",
+      "vulnerabilities": []
+    },
+    {
+      "testCaseName": "fixed-language-package-vulnerabilities",
+      "vulnerabilities": []
+    },
+    {
+      "testCaseName": "false-positive-language-package-vulnerabilities",
+      "vulnerabilities": []
+    },
+    {
+      "testCaseName": "subpackage-fixed-vulnerabilities",
+      "vulnerabilities": []
+    },
+    {
+      "testCaseName": "unfixed-vulnerabilities",
+      "vulnerabilities": [
+        ["CVE-2023-25139", "GHSA-2g67-jw5m-244m"],
+        ["CVE-2023-4911", "GHSA-m77w-6vjw-wh2f"],
+        ["CVE-2023-5156", "GHSA-m7p3-g2hx-xfc3"],
+        ["CVE-2023-6246", "GHSA-p6rw-gvvh-q8v4"],
+        ["CVE-2023-6779", "GHSA-p5vr-h433-qhqr"],
+        ["CVE-2023-4527", "GHSA-hmf7-f8gf-8f4p"],
+        ["CVE-2023-6780", "GHSA-jjr8-97p7-vmmg"],
+        ["CVE-2024-2961", "GHSA-22q4-f5r6-3xqw"],
+        ["CVE-2024-33599", "GHSA-9gvm-vcgf-x5xw"],
+        ["CVE-2024-33600", "GHSA-jv3g-6pg3-v9j8"],
+        ["CVE-2024-33601", "GHSA-f4cf-2w52-c853"],
+        ["CVE-2024-33602", "GHSA-f4pv-q5f7-2h55"]
+      ]
+    },
+    {
+      "testCaseName": "subpackage-unfixed-vulnerabilities",
+      "vulnerabilities": [
+        ["CVE-2022-4450", "GHSA-v5w6-wcm8-jm4q"],
+        ["CVE-2023-0215", "GHSA-r7jw-wp68-3xch"],
+        ["CVE-2023-0216", "GHSA-29xx-hcv2-c4cp"],
+        ["CVE-2023-0217", "GHSA-vxrh-cpg7-8vjr"],
+        ["CVE-2023-0286", "GHSA-x4qr-2fvf-3mr5"],
+        ["CVE-2023-0401", "GHSA-vrh7-x64v-7vxq"],
+        ["CVE-2023-0464", "GHSA-w2w6-xp88-5cvw"],
+        ["CVE-2023-5363", "GHSA-xw78-pcr6-wrg8"],
+        ["CVE-2022-4203", "GHSA-w67w-mw4j-8qrv"],
+        ["CVE-2022-4304", "GHSA-p52g-cm5j-mjv4"],
+        ["CVE-2023-0465", "GHSA-77f3-6546-6rj7"],
+        ["CVE-2023-1255", "GHSA-4wp2-xw7p-2gfx"],
+        ["CVE-2023-2650", "GHSA-gqxg-9vfr-p9cg"],
+        ["CVE-2023-2975", "GHSA-hpqg-7fjp-436p"],
+        ["CVE-2023-3446", "GHSA-3p3x-vg38-6g9q"],
+        ["CVE-2023-3817", "GHSA-c945-cqj5-wfv6"],
+        ["CVE-2023-5678", "GHSA-2cj7-mg3x-9mhq"],
+        ["CVE-2024-0727", "GHSA-9v9h-cgj8-h64p"],
+        ["CVE-2023-6237", "GHSA-hvc4-mjv4-5mw6"],
+        ["CVE-2024-2511", "GHSA-299c-jvhc-gxj8"],
+        ["CVE-2024-4603", "GHSA-85xr-ghj6-6m46"]
+      ]
+    }
+  ]
+}

--- a/docs/verifying_scan_results.md
+++ b/docs/verifying_scan_results.md
@@ -2,126 +2,99 @@
 
 Once you've implemented supported for Chainguard Images, it's time to verify that your scanner is producing the correct results during image scans.
 
-Chainguard provides special images that are designed to help scanner developers test their work. And these same images help Chainguard verify that a scanner has successfully implemented support for Chainguard Images.
+Chainguard provides special **test images** that are designed to help scanner developers validate their implementation. And these same images help _Chainguard_ verify that a given scanner has successfully implemented support for Chainguard Images.
 
-## Test Images
+These images are organized into **test cases**.
 
-Each of these image tags are available in both `-wolfi` and `-chainguard` flavors. This tag suffix indicates which distro is indicated in the image's `/etc/os-release` file, and thus [which of the two secdbs should be used](./scanning_implementation.md#selecting-the-correct-vulnerability-data-set). For brevity, the image references below just show the `-wolfi` flavor.
+## Test Cases
 
-### `ghcr.io/chainguard-images/scanner-test:no-software-wolfi`
+We can measure the "readiness" of a scanner's support for Chainguard Images by testing if the scanner produces the expected the set of vulnerabilities for each specially crafted "test case".
 
-**Expected:** no vulnerabilities
+Each test case has two variation of the same image — one with the `wolfi` distro ID, and one with the `chainguard` distro ID. These images have tags suffixed with `-wolfi` and `-chainguard`, respectively. Aside from this difference in distro identification, the two variations within each test case are equivalent, and should produce an identical set of vulnerabilities.
 
-**Why:** This image contains no executable software. The only packages installed are `wolfi-baselayout` and `ca-certificates-bundle`, which together provide a minimal directory structure and basic data files for the image, such as `/etc/os-release` and root CA certificates.
+Each test case and its images are listed below, along with an explanation of why we've included that test case.
 
-### `ghcr.io/chainguard-images/scanner-test:fixed-vulnerabilities-wolfi`
+The "answer sheet" of the correct vulnerability IDs expected to be surfaced for each test case are stored in JSON in this repository, at `data/answers.json`.
 
-**Expected:** no vulnerabilities
+### no-software
 
-**Why:** This image includes a few software packages, like `busybox` and `glibc`, but none of the packages in this image currently have any known vulnerabilities. Some of these packages have had vulnerabilities _in the past_, but Chainguard has resolved the vulnerabilities and noted the fixes in the secdb.
+#### Test Images
 
-### `ghcr.io/chainguard-images/scanner-test:fixed-language-package-vulnerabilities-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:no-software-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:no-software-chainguard`
 
-**Expected:** no vulnerabilities
+#### Explanation
 
-**Why:** This image includes a distro package (`ko`) that includes several language ecosystem packages (Go modules, in this case). These language ecosystem packages have been the source of vulnerabilities in the past, but those have been resolved in the current version of the distro package.
+This image contains no executable software. The only packages installed are `wolfi-baselayout` and `ca-certificates-bundle`, which together provide a minimal directory structure and basic data files for the image, such as `/etc/os-release` and root CA certificates.
 
-### `ghcr.io/chainguard-images/scanner-test:false-positive-language-package-vulnerabilities-wolfi`
+### fixed-vulnerabilities
 
-**Expected:** no vulnerabilities
+#### Test Images
 
-**Why:** This image is similar to `:fixed-language-package-vulnerabilities-wolfi`, but in this case, there have been false positives reported against the language ecosystem packages contained within the distro package. Those false positives are disclaimed in the secdb, and scanners should consequently not surface the false positives if they would have otherwise.
+- `ghcr.io/chainguard-images/scanner-test:fixed-vulnerabilities-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:fixed-vulnerabilities-chainguard`
 
-### `ghcr.io/chainguard-images/scanner-test:subpackage-fixed-vulnerabilities-wolfi`
+#### Explanation
 
-**Expected:** no vulnerabilities
+This image includes a few software packages, like `busybox` and `glibc`, but none of the packages in this image currently have any known vulnerabilities. Some of these packages have had vulnerabilities _in the past_, but Chainguard has resolved the vulnerabilities and noted the fixes in the secdb.
 
-**Why:** This image contains the latest version of `libcrypto3`, which is a subpackage of `openssl`. While there is vulnerability data about `openssl` in the secdb that applies to `libcrypto3`, the installed version of `libcrypto3` is the latest version and contains patches for all vulnerabilities listed in the secdb entry.
+### fixed-language-package-vulnerabilities
 
-### `ghcr.io/chainguard-images/scanner-test:unfixed-vulnerabilities-wolfi`
+#### Test Images
 
-**Expected:**
+- `ghcr.io/chainguard-images/scanner-test:fixed-language-package-vulnerabilities-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:fixed-language-package-vulnerabilities-chainguard`
 
-- CVE-2023-25139
-- CVE-2023-4911
-- CVE-2023-5156
-- CVE-2023-6246
-- CVE-2023-6779
-- CVE-2023-4527
-- CVE-2023-6780 
+#### Explanation
 
-**Why:** This image contains an **intentionally outdated** version of `glibc`, to see if scanners recognize that there's a vulnerability in this package that's fixed in a _later_ version of the package.
+This image includes a distro package (`ko`) that includes several language ecosystem packages (Go modules, in this case). These language ecosystem packages have been the source of vulnerabilities in the past, but those have been resolved in the current version of the distro package.
 
-### `ghcr.io/chainguard-images/scanner-test:unfixed-vulnerabilities-many-wolfi`
+### false-positive-language-package-vulnerabilities
 
-**Expected:**
+#### Test Images
 
-`binutils`:
+- `ghcr.io/chainguard-images/scanner-test:false-positive-language-package-vulnerabilities-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:false-positive-language-package-vulnerabilities-chainguard`
 
-- CVE-2023-1579
-- CVE-2023-1972
+#### Explanation
 
-`git`:
+This image is similar to `:fixed-language-package-vulnerabilities-wolfi`, but in this case, there have been false positives reported against the language ecosystem packages contained within the distro package. Those false positives are disclaimed in the secdb, and scanners should consequently not surface the false positives if they would have otherwise.
 
-- CVE-2022-41903
-- CVE-2022-23521
-- CVE-2023-29007
-- CVE-2023-25652
-- CVE-2023-23946
-- CVE-2023-22490
+### subpackage-fixed-vulnerabilities
 
-`openssl`:
+#### Test Images
 
-- CVE-2023-0464
-- CVE-2023-0401
-- CVE-2023-0286
-- CVE-2023-0217
-- CVE-2023-0216
-- CVE-2023-0215
-- CVE-2022-4450
-- CVE-2022-3996
-- CVE-2023-3817
-- CVE-2023-3446
-- CVE-2023-2975
-- CVE-2023-2650
-- CVE-2023-1255
-- CVE-2023-0465
-- CVE-2022-4304
-- CVE-2022-4203
+- `ghcr.io/chainguard-images/scanner-test:subpackage-fixed-vulnerabilities-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:subpackage-fixed-vulnerabilities-chainguard`
 
-`sysstat`:
+#### Explanation
 
-- CVE-2023-33204
+This image contains the latest version of `libcrypto3`, which is a subpackage of `openssl`. While there is vulnerability data about `openssl` in the secdb that applies to `libcrypto3`, the installed version of `libcrypto3` is the latest version and contains patches for all vulnerabilities listed in the secdb entry.
 
-**Why:** This image contains **intentionally outdated** versions of `binutils`, `git`, `openssl`, and `sysstat`. This image is similar to `:unfixed-vulnerabilities-wolfi`, but just adds a larger quantity of expected vulnerabilities.
+### unfixed-vulnerabilities
 
-### `ghcr.io/chainguard-images/scanner-test:subpackage-unfixed-vulnerabilities-wolfi`
+#### Test Images
 
-**Expected:**
+- `ghcr.io/chainguard-images/scanner-test:unfixed-vulnerabilities-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:unfixed-vulnerabilities-chainguard`
 
-- CVE-2022-4450
-- CVE-2023-0215
-- CVE-2023-0216
-- CVE-2023-0217
-- CVE-2023-0286
-- CVE-2023-0401
-- CVE-2023-0464
-- CVE-2023-5363
-- CVE-2022-4203
-- CVE-2022-4304
-- CVE-2023-0465
-- CVE-2023-1255
-- CVE-2023-2650
-- CVE-2023-2975
-- CVE-2023-3446
-- CVE-2023-3817
-- CVE-2023-5678
-- CVE-2024-0727
+#### Explanation
 
-**Why:** This image contains an **intentionally outdated** version of `libcrypto3`. `libcrypto3` is a subpackage of `openssl`, and the relevant secdb data is filed under `openssl`. This image tests that scanners understand how to relate subpackages to origin package data to find unfixed vulnerabilities.
+This image contains an **intentionally outdated** version of `glibc`, to see if scanners recognize that there's a vulnerability in this package that's fixed in a _later_ version of the package.
+
+### subpackage-unfixed-vulnerabilities
+
+#### Test Images
+
+- `ghcr.io/chainguard-images/scanner-test:subpackage-unfixed-vulnerabilities-wolfi`
+- `ghcr.io/chainguard-images/scanner-test:subpackage-unfixed-vulnerabilities-chainguard`
+
+#### Explanation
+
+This image contains an **intentionally outdated** version of `libcrypto3`. `libcrypto3` is a subpackage of `openssl`, and the relevant secdb data is filed under `openssl`. This image tests that scanners understand how to relate subpackages to origin package data to find unfixed vulnerabilities.
 
 ---
 
-**Note:** While the intent is to keep this list of images and their vulnerabilities as correct as possible, new vulnerabilities are published frequently, and there may be cases where a novel CVE correctly shows in a scan result even though it's not listed here. This data was last verified on **September 14, 2023**, so treat scan result items for vulnerabilities published after this date with caution.
+**Note:** While the intent is to keep this list of images and their vulnerabilities as correct as possible, new vulnerabilities are published frequently, and there may be cases where a novel CVE correctly shows in a scan result even though it's not listed here. This data was last verified on **June 27, 2024**, so treat scan result items for vulnerabilities published after this date with caution.
 
 **Feedback is welcome!** If you have suggestions for test cases that would be useful to you, please feel free to file an issue. Better collaboration leads to higher quality scans. 🚀


### PR DESCRIPTION
* move expected results to machine-readable JSON file
* improve formatting and explanation of the verification process
* remove `unfixed-vulnerabilities-many` test case, since it did not have a unique purpose