### PR TITLE
Insert section header for security feeds

### DIFF
--- a/docs/foundational_concepts.md
+++ b/docs/foundational_concepts.md
@@ -34,9 +34,11 @@ Chainguard staff members carefully review potential vulnerabilities in our publi
 
 In its raw form, advisory data is stored as YAML and version-controlled using git. We operate on the data using [wolfictl](https://github.com/wolfi-dev/wolfictl). The [Wolfi advisory data repository](https://github.com/wolfi-dev/advisories) is public, while the repository for Chainguard's enterprise packages is not public.
 
-We can use advisory data to produce different kinds of downstream data. One kind of downstream artifact we produce using advisory data is a "secdb".
+We can use advisory data to produce different kinds of downstream data. The primary downstream use of this data is our security feeds, intended for consumption by vulnerability scanners.
 
-### The secdb
+### Security feeds
+
+#### The secdb
 
 A secdb is a JSON file that uses the same schema as the Alpine distro's security feeds.
 
@@ -46,7 +48,7 @@ The "Wolfi secdb" is located at `https://packages.wolfi.dev/os/security.json`.
 
 The "Chainguard secdb" is located at `https://packages.cgr.dev/chainguard/security.json`.
 
-#### Interpreting secdb data
+##### Interpreting secdb data
 
 The secdb JSON document has a number of properties. The important property for scanners to examine is `packages`. This is an array of package objects, where each object has a `name` string property and a `secfixes` object property.
 
@@ -86,7 +88,7 @@ For example, here's an excerpt of the Wolfi secdb:
 
 From this data, we can see that the Wolfi package named `apko`, in its version `0.7.3-r1`, resolved three CVEs: `CVE-2023-28840`, `CVE-2023-28841`, and `CVE-2023-28842`.
 
-### OSV feed
+#### OSV feed
 
 As an alternative to the secdb, we've just launched a new _OSV_ feed. If you're unfamiliar with the OSV format, check out https://ossf.github.io/osv-schema/.
 
@@ -98,7 +100,7 @@ An index of Chainguard's OSV data is located at `https://packages.cgr.dev/chaing
 
 Each individual Chainguard advisory is represented as its own file, where the advisory ID (prefixed with `CGA-`) replaces the "all" in the URL above. For example, the advisory CGA-2226-2498-2frm is located at `https://packages.cgr.dev/chainguard/osv/CGA-2226-2498-2frm.json`.
 
-### Update frequency
+#### Update frequency
 
 Both Chainguard's secdbs and the OSV feed are updated frequently, as soon as new data is available in our central advisory data store. This means that both data feed mechanisms usually receive updates several times a day.
 


### PR DESCRIPTION
To support more targeted linking to the content on security feeds.